### PR TITLE
update 'http' dependency to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,20 +6,21 @@ edition = "2021"
 [dependencies]
 bytes = "1"
 futures-util = { version = "0.3", default_features = false, features = [] }
-http = "0.2"
-http-body = "0.4.1"
+http = "1"
+http-body = "1"
+http-body-util = "0.1"
 pin-project = "1"
 tower-service = "0.3"
 
 mime = "0.3"
 mime_guess = "2"
 tokio = { version = "1", default_features = false, features = ["fs"] }
-tokio-util = { version = "0.6", default_features = false, features = ["io"] }
+tokio-util = { version = "0.7", default_features = false, features = ["io"] }
 percent-encoding = "2.1.0"
 
 include_dir = "0.7.0"
 
 [dev-dependencies]
-hyper = { version = "0.14", features = ["full"] }
+axum = { version = "0.7.3" }
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.4.10", features = ["buffer", "util", "retry", "make"] }

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ use tower_serve_static::{ServeFile, include_file};
 // This will embed and serve the `README.md` file.
 let service = ServeFile::new(include_file!("/README.md"));
 
-// Run our service using `hyper`
-let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 3000));
-hyper::Server::bind(&addr)
-    .serve(tower::make::Shared::new(service))
-    .await
-    .expect("server error");
+// Run our service using `axum`
+let app = axum::Router::new().nest_service("/", service);
+
+// run our app with axum, listening locally on port 3000
+let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
+axum::serve(listener, app).await?;
 ```
 
 ### Serve Static Directory
@@ -44,12 +44,12 @@ use include_dir::{Dir, include_dir};
 static ASSETS_DIR: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/src");
 let service = ServeDir::new(&ASSETS_DIR);
 
-// Run our service using `hyper`
-let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 3000));
-hyper::Server::bind(&addr)
-    .serve(tower::make::Shared::new(service))
-    .await
-    .expect("server error");
+// Run our service using `axum`
+let app = axum::Router::new().nest_service("/", service);
+
+// run our app with axum, listening locally on port 3000
+let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
+axum::serve(listener, app).await?;
 ```
 
 ## Credits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,9 +112,10 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        self.project()
-            .reader
-            .poll_next(cx)
-            .map(|x| x.map(|y| y.map(|z| Frame::data(z))))
+        self.project().reader.poll_next(cx).map(|res| match res {
+            Some(Ok(buf)) => Some(Ok(Frame::data(buf))),
+            Some(Err(err)) => Some(Err(err)),
+            None => None,
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,14 @@
 //! // This will embed and serve the `README.md` file.
 //! let service = ServeFile::new(include_file!("/README.md"));
 //!
+//! // Run our service using `axum`
+//! let app = axum::Router::new().nest_service("/", service);
+//!
 //! # async {
-//! // Run our service using `hyper`
-//! let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 3000));
-//! hyper::Server::bind(&addr)
-//!     .serve(tower::make::Shared::new(service))
-//!     .await
-//!     .expect("server error");
+//! // run our app with axum, listening locally on port 3000
+//! let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
+//! axum::serve(listener, app).await?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! # };
 //! ```
 //!
@@ -30,13 +31,14 @@
 //! static ASSETS_DIR: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/src");
 //! let service = ServeDir::new(&ASSETS_DIR);
 //!
+//! // Run our service using `axum`
+//! let app = axum::Router::new().nest_service("/", service);
+//!
+//! // run our app with axum, listening locally on port 3000
 //! # async {
-//! // Run our service using `hyper`
-//! let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 3000));
-//! hyper::Server::bind(&addr)
-//!     .serve(tower::make::Shared::new(service))
-//!     .await
-//!     .expect("server error");
+//! let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
+//! axum::serve(listener, app).await?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! # };
 //! ```
 
@@ -52,8 +54,7 @@ pub mod private {
 }
 
 use bytes::Bytes;
-use http::HeaderMap;
-use http_body::Body;
+use http_body::{Body, Frame};
 use pin_project::pin_project;
 use std::{
     io,
@@ -107,17 +108,13 @@ where
     type Data = Bytes;
     type Error = io::Error;
 
-    fn poll_data(
+    fn poll_frame(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
-        self.project().reader.poll_next(cx)
-    }
-
-    fn poll_trailers(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
-        Poll::Ready(Ok(None))
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        self.project()
+            .reader
+            .poll_next(cx)
+            .map(|x| x.map(|y| y.map(|z| Frame::data(z))))
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,19 +15,11 @@ macro_rules! opaque_body {
             type Error = <$actual as http_body::Body>::Error;
 
             #[inline]
-            fn poll_data(
+            fn poll_frame(
                 self: std::pin::Pin<&mut Self>,
                 cx: &mut std::task::Context<'_>,
-            ) -> std::task::Poll<Option<Result<Self::Data, Self::Error>>> {
-                self.project().0.poll_data(cx)
-            }
-
-            #[inline]
-            fn poll_trailers(
-                self: std::pin::Pin<&mut Self>,
-                cx: &mut std::task::Context<'_>,
-            ) -> std::task::Poll<Result<Option<http::HeaderMap>, Self::Error>> {
-                self.project().0.poll_trailers(cx)
+            ) -> std::task::Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+                self.project().0.poll_frame(cx)
             }
 
             #[inline]


### PR DESCRIPTION
Also change examples to axum 0.7, which uses hyper 1.

The error type was changed from `io::Error`, which was never returned to the best of my knowledge, to `Infallible`, which both guarantees that it will never be returned and is also compatible with axum.