### PR TITLE
Supports last-modified response header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,13 @@ tokio = { version = "1", default_features = false, features = ["fs"] }
 tokio-util = { version = "0.7", default_features = false, features = ["io"] }
 percent-encoding = "2.1.0"
 
-include_dir = "0.7.0"
+include_dir = { version = "0.7.3", default_features = false, features = [] }
+httpdate = { version = "1", optional = true }
 
 [dev-dependencies]
 axum = { version = "0.7.3" }
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.4.10", features = ["buffer", "util", "retry", "make"] }
+
+[features]
+metadata = ["dep:httpdate", "include_dir/metadata"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,13 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! # };
 //! ```
+//!
+//! # Features
+//!
+//! This library exposes the following features can be enabled:
+//!
+//! - `metadata` - enables `ServeDir` to include the `Last-Modified` header in the response headers.
+//!   Additionally, it enables responding with a suitable reply for `If-Modified-Since` conditional requests.
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,9 @@
 //!
 //! # Features
 //!
-//! This library exposes the following features can be enabled:
+//! This library exposes the following features that can be enabled:
 //!
-//! - `metadata` - enables `ServeDir` to include the `Last-Modified` header in the response headers.
+//! - `metadata` - enables [`ServeDir`] to include the `Last-Modified` header in the response headers.
 //!   Additionally, it enables responding with a suitable reply for `If-Modified-Since` conditional requests.
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,10 +129,11 @@ fn unmodified_since_request_condition<T>(file: &include_dir::File, req: &http::R
         return false;
     };
 
-    // When used in combination with If-None-Match, it is ignored, unless the server doesn't support If-None-Match.
-    if req.headers().contains_key(header::IF_NONE_MATCH) {
-        return false;
-    }
+    // If-Modified-Since header spec says:
+    //
+    // > When used in combination with If-None-Match, it is ignored, unless the server doesn't support If-None-Match.
+    //
+    // We can ignore the If-None-Match header is exists or not, because we currently do not support If-None-Match.
 
     // If-Modified-Since can only be used with a GET or HEAD.
     match req.method() {

--- a/src/serve_dir.rs
+++ b/src/serve_dir.rs
@@ -277,12 +277,10 @@ mod tests {
         #[cfg(not(feature = "metadata"))]
         {
             assert!(!res.headers().contains_key("last-modified"));
-            assert!(!res.headers().contains_key("etag"));
         }
         #[cfg(feature = "metadata")]
         {
             assert!(res.headers().contains_key("last-modified"));
-            assert!(!res.headers().contains_key("etag"));
         }
 
         let body = body_into_text(res.into_body()).await;
@@ -317,7 +315,6 @@ mod tests {
         assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
         assert!(!res.headers().contains_key("content-type"));
         assert!(!res.headers().contains_key("last-modified"));
-        assert!(!res.headers().contains_key("etag"));
         assert!(body_into_text(res.into_body()).await.is_empty());
     }
 


### PR DESCRIPTION
Added "metadata" feature.
If feature flag “metadata” enabled, includes Last-Modified response header and can conditional response with If-Modified-Since.