### PR TITLE
Fix authority only uri

### DIFF
--- a/src/serve_dir.rs
+++ b/src/serve_dir.rs
@@ -71,6 +71,12 @@ impl<ReqBody> Service<Request<ReqBody>> for ServeDir {
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        if req.uri().authority().is_some() && req.uri().scheme().is_none() {
+            return ResponseFuture {
+                inner: Some(Inner::Invalid),
+            };
+        }
+
         // build and validate the path
         let path = req.uri().path();
         let path = path.trim_start_matches('/');
@@ -159,9 +165,9 @@ fn append_slash_on_path(uri: Uri) -> Uri {
     let mut builder = Uri::builder();
     if let Some(scheme) = scheme {
         builder = builder.scheme(scheme);
-    }
-    if let Some(authority) = authority {
-        builder = builder.authority(authority);
+        if let Some(authority) = authority {
+            builder = builder.authority(authority);
+        }
     }
     if let Some(path_and_query) = path_and_query {
         if let Some(query) = path_and_query.query() {

--- a/src/serve_dir.rs
+++ b/src/serve_dir.rs
@@ -71,12 +71,6 @@ impl<ReqBody> Service<Request<ReqBody>> for ServeDir {
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        if req.uri().authority().is_some() && req.uri().scheme().is_none() {
-            return ResponseFuture {
-                inner: Some(Inner::Invalid),
-            };
-        }
-
         // build and validate the path
         let path = req.uri().path();
         let path = path.trim_start_matches('/');
@@ -101,9 +95,12 @@ impl<ReqBody> Service<Request<ReqBody>> for ServeDir {
 
         if !req.uri().path().ends_with('/') {
             if is_dir(self.dir, &full_path) {
-                let location =
-                    HeaderValue::from_str(&append_slash_on_path(req.uri().clone()).to_string())
-                        .unwrap();
+                let Ok(uri) = append_slash_on_path(req.uri().clone()) else {
+                    return ResponseFuture {
+                        inner: Some(Inner::Invalid),
+                    };
+                };
+                let location = HeaderValue::from_str(&uri.to_string()).unwrap();
                 return ResponseFuture {
                     inner: Some(Inner::Redirect(location)),
                 };
@@ -154,7 +151,7 @@ fn is_dir(dir: &Dir<'static>, path: &Path) -> bool {
     dir.get_dir(path).is_some()
 }
 
-fn append_slash_on_path(uri: Uri) -> Uri {
+fn append_slash_on_path(uri: Uri) -> http::Result<Uri> {
     let http::uri::Parts {
         scheme,
         authority,
@@ -165,9 +162,9 @@ fn append_slash_on_path(uri: Uri) -> Uri {
     let mut builder = Uri::builder();
     if let Some(scheme) = scheme {
         builder = builder.scheme(scheme);
-        if let Some(authority) = authority {
-            builder = builder.authority(authority);
-        }
+    }
+    if let Some(authority) = authority {
+        builder = builder.authority(authority);
     }
     if let Some(path_and_query) = path_and_query {
         if let Some(query) = path_and_query.query() {
@@ -179,7 +176,7 @@ fn append_slash_on_path(uri: Uri) -> Uri {
         builder = builder.path_and_query("/");
     }
 
-    builder.build().unwrap()
+    builder.build()
 }
 
 enum Inner {

--- a/src/serve_dir.rs
+++ b/src/serve_dir.rs
@@ -453,6 +453,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn authority_form_uri_does_not_panic() {
+        // Authority-form URIs (e.g. "localhost:8080") have authority but no scheme.
+        // Per RFC 3986, a URI with authority always requires a scheme; authority-form
+        // is only valid for CONNECT requests (RFC 7230 §5.3.3).
+        // ServeDir should reject these gracefully instead of panicking in
+        // append_slash_on_path when rebuilding the URI via Uri::from_parts.
+        let svc = ServeDir::new(&ASSETS_DIR);
+
+        let uri: Uri = "localhost:8080".parse().unwrap();
+        assert!(uri.authority().is_some());
+        assert!(uri.scheme().is_none());
+
+        let req = Request::builder()
+            .uri(uri)
+            .body(http_body_util::Empty::<Bytes>::new())
+            .unwrap();
+        let res = svc.oneshot(req).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
     async fn access_space_percent_encoded_uri_path() {
         let svc = ServeDir::new(&ASSETS_DIR);
 


### PR DESCRIPTION
Authority only URI (invalid) like `localhost:8080` will panic the server when parsing URI.

According to  RFC 3986 Section 3:

> The scheme and path components are required, though the path may be empty (no characters).

and RFC 7230 Section 5.3.3:

>  The authority-form of request-target is only used for CONNECT requests.

We should reject these URIs and only add authority when there's a scheme